### PR TITLE
feat(filter): query tags before a given version threshold

### DIFF
--- a/cmd/skopeo/list_tags.go
+++ b/cmd/skopeo/list_tags.go
@@ -10,13 +10,17 @@ import (
 	"slices"
 	"strings"
 
+	commonFlag "github.com/containers/common/pkg/flag"
 	"github.com/containers/common/pkg/retry"
 	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/docker/archive"
 	"github.com/containers/image/v5/docker/reference"
+	"github.com/containers/image/v5/image"
 	"github.com/containers/image/v5/transports/alltransports"
 	"github.com/containers/image/v5/types"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/mod/semver"
 )
 
 // tagListOutput is the output format of (skopeo list-tags), primarily so that we can format it with a simple json.MarshalIndent.
@@ -25,10 +29,48 @@ type tagListOutput struct {
 	Tags       []string
 }
 
+type filteredTags struct {
+	ToPrune []string
+	ToKeep  []string
+	Invalid []string
+}
+
+func newFilteredTags() *filteredTags {
+	return &filteredTags{
+		ToPrune: make([]string, 0),
+		ToKeep:  make([]string, 0),
+		Invalid: make([]string, 0),
+	}
+}
+
+type tagFilterOptions struct {
+	BeforeVersion commonFlag.OptionalString
+	VersionLabel  commonFlag.OptionalString
+	Valid         commonFlag.OptionalBool
+	Invalid       commonFlag.OptionalBool
+	SingleStream  commonFlag.OptionalBool
+}
+
+func (opts *tagFilterOptions) FilterPresent() bool {
+	return opts.BeforeVersion.Present() || opts.Valid.Present() || opts.Invalid.Present()
+}
+
+func filterFlags() (pflag.FlagSet, *tagFilterOptions) {
+	opts := tagFilterOptions{}
+	fs := pflag.FlagSet{}
+	fs.Var(commonFlag.NewOptionalStringValue(&opts.BeforeVersion), "before-version", "A version threshold prior to which to list tags")
+	fs.Var(commonFlag.NewOptionalStringValue(&opts.VersionLabel), "version-label", "A label from which to derive the version for each tag")
+	commonFlag.OptionalBoolFlag(&fs, &opts.Valid, "valid", "Whether to list only tags with valid semver")
+	commonFlag.OptionalBoolFlag(&fs, &opts.Invalid, "invalid", "Whether to list only tags with invalid semver")
+	commonFlag.OptionalBoolFlag(&fs, &opts.SingleStream, "single-stream", "Whether to only list versions matching the Major.Minor of the --before-version threshold")
+	return fs, &opts
+}
+
 type tagsOptions struct {
-	global    *globalOptions
-	image     *imageOptions
-	retryOpts *retry.Options
+	global     *globalOptions
+	image      *imageOptions
+	retryOpts  *retry.Options
+	filterOpts *tagFilterOptions
 }
 
 var transportHandlers = map[string]func(ctx context.Context, sys *types.SystemContext, opts *tagsOptions, userInput string) (repositoryName string, tagListing []string, err error){
@@ -46,11 +88,13 @@ func tagsCmd(global *globalOptions) *cobra.Command {
 	sharedFlags, sharedOpts := sharedImageFlags()
 	imageFlags, imageOpts := dockerImageFlags(global, sharedOpts, nil, "", "")
 	retryFlags, retryOpts := retryFlags()
+	filterFlags, filterOpts := filterFlags()
 
 	opts := tagsOptions{
 		global:    global,
 		image:     imageOpts,
 		retryOpts: retryOpts,
+		filterOpts: filterOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -71,6 +115,7 @@ See skopeo-list-tags(1) section "REPOSITORY NAMES" for the expected format
 	flags.AddFlagSet(&sharedFlags)
 	flags.AddFlagSet(&imageFlags)
 	flags.AddFlagSet(&retryFlags)
+	flags.AddFlagSet(&filterFlags)
 	return cmd
 }
 
@@ -95,14 +140,178 @@ func parseDockerRepositoryReference(refString string) (types.ImageReference, err
 	return docker.NewReference(reference.TagNameOnly(ref))
 }
 
+func getValidSemverString(version string) (string, error) {
+	// Return the version string if it's valid on its own
+	if semver.IsValid(version) {
+		return version, nil
+	}
+
+	// Append a "v" prefix onto the version string if it's missing one
+	modifiedVersion := fmt.Sprintf("v%s", version)
+	if semver.IsValid(modifiedVersion) {
+		return modifiedVersion, nil
+	}
+
+	// If neither are valid, then the version string itself is bad
+	return "", fmt.Errorf("invalid semver: %s", version)
+}
+
+func filterDockerTagBySemver(filtered *filteredTags, opts *tagsOptions, thresholdVersion string, tag string, tagVersion string) (error) {
+	// Parse the threshold & tag versions
+	validThreshold, err := getValidSemverString(thresholdVersion)
+	if err != nil {
+		return fmt.Errorf("invalid semver in version threshold: %w", err)
+	}
+	validTagVersion, err := getValidSemverString(tagVersion)
+
+	// If the tag version is invalid, then filter it as such
+	if err != nil {
+		filtered.Invalid = append(filtered.Invalid, tag)
+		return nil
+	}
+
+	// If single stream, keep all tags not matching threshold Major.Minor
+	if opts.filterOpts.SingleStream.Present() && opts.filterOpts.SingleStream.Value() {
+		if semver.MajorMinor(validThreshold) != semver.MajorMinor(validTagVersion) {
+			filtered.ToKeep = append(filtered.ToKeep, tag)
+			return nil
+		}
+	}
+
+	// Compare the tag semver against the threshold semver
+	cmp := semver.Compare(validThreshold, validTagVersion)
+	if cmp < 0 {
+		filtered.ToKeep = append(filtered.ToKeep, tag)
+	} else {
+		filtered.ToPrune = append(filtered.ToPrune, tag)
+	}
+	return nil
+}
+
+func filterDockerTagsByTagSemver(opts *tagsOptions, tags *tagListOutput) (*filteredTags, error) {
+	// Get the user-provided threshold version
+	// This will be validated later when the comparison takes place
+	var threshold string
+	if opts.filterOpts.BeforeVersion.Present() {
+		threshold = opts.filterOpts.BeforeVersion.Value()
+	} else {
+		// Set as an arbitrary valid version since this isn't going to affect output
+		threshold = "v0.1.0"
+	}
+
+	// Loop through each tag and sort into to prune, to keep, and, invalid
+	filtered := newFilteredTags()
+	for _, tag := range tags.Tags {
+		err := filterDockerTagBySemver(filtered, opts, threshold, tag, tag)
+		if err != nil {
+			return nil, fmt.Errorf("Error filtering tags: %w", err)
+		}
+	}
+	return filtered, nil
+}
+
+func filterDockerTagsByLabelSemver(ctx context.Context, sys *types.SystemContext, opts *tagsOptions, tags *tagListOutput) (filtered *filteredTags, retErr error) {
+	// Get the user-provided threshold version
+	// This will be validated later when the comparison takes place
+	var threshold string
+	if opts.filterOpts.BeforeVersion.Present() {
+		threshold = opts.filterOpts.BeforeVersion.Value()
+	} else {
+		// Set as an arbitrary valid version since this isn't going to affect output
+		threshold = "v0.1.0"
+	}
+
+	// Loop through each tag and inspect for its labels
+	filtered = newFilteredTags()
+	for _, tag := range tags.Tags {
+		var (
+			src         types.ImageSource
+			imgInspect  *types.ImageInspectInfo
+			err error
+		)
+
+		// Reconstruct the image reference and inspect it, borrowed from inspect implementation
+		// Hardcode to docker:// as we know only this transport will trigger this function
+		imageName := fmt.Sprintf("docker://%s:%s", tags.Repository, tag)
+		if err := retry.IfNecessary(ctx, func() error {
+			src, err = parseImageSource(ctx, opts.image, imageName)
+			return err
+		}, opts.retryOpts); err != nil {
+			return nil, fmt.Errorf("Error parsing image name %q: %w", imageName, err)
+		}
+		defer func() {
+			if err := src.Close(); err != nil {
+				retErr = noteCloseFailure(retErr, "closing image", err)
+			}
+		}()
+		unparsedInstance := image.UnparsedInstance(src, nil)
+		img, err := image.FromUnparsedImage(ctx, sys, unparsedInstance)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing manifest for image: %w", err)
+		}
+		if err := retry.IfNecessary(ctx, func() error {
+			imgInspect, err = img.Inspect(ctx)
+			return err
+		}, opts.retryOpts); err != nil {
+			return nil, err
+		}
+
+		// Get the version label and compare
+		versionLabel := opts.filterOpts.VersionLabel.Value()
+		tagVersion, ok := imgInspect.Labels[versionLabel]
+		if !ok {
+			return nil, fmt.Errorf("Version label not found: %s", versionLabel)
+		}
+		err = filterDockerTagBySemver(filtered, opts, threshold, tag, tagVersion)
+		if err != nil {
+			return nil, fmt.Errorf("Error filtering tags: %w", err)
+		}
+	}
+	return filtered, nil
+}
+
+func filterDockerTags(ctx context.Context, sys *types.SystemContext, opts *tagsOptions, repositoryName string, tags []string) (string, []string, error) {
+	tagList := &tagListOutput{
+		Repository: repositoryName,
+		Tags:       tags,
+	}
+	var filtered *filteredTags
+	var err error
+	if opts.filterOpts.VersionLabel.Present() {
+		filtered, err = filterDockerTagsByLabelSemver(ctx, sys, opts, tagList)
+	} else {
+		filtered, err = filterDockerTagsByTagSemver(opts, tagList)
+	}
+	if err != nil {
+		return ``, nil, fmt.Errorf("Error filtering tags by semver: %w", err)
+	}
+	if opts.filterOpts.BeforeVersion.Present() {
+		// Optionally only list tags prior to given semver threshold
+		return repositoryName, filtered.ToPrune, nil
+	} else if opts.filterOpts.Invalid.Present() {
+		// Optionally only list tags with invalid semver
+		return repositoryName, filtered.Invalid, nil
+	} else { // Then only --valid could have possibly been set
+		// Optionally only list tags with valid semver
+		valid := append(filtered.ToKeep, filtered.ToPrune...)
+		return repositoryName, valid, nil
+	}
+}
+
 // List the tags from a repository contained in the imgRef reference. Any tag value in the reference is ignored
-func listDockerTags(ctx context.Context, sys *types.SystemContext, imgRef types.ImageReference) (string, []string, error) {
+func listDockerTags(ctx context.Context, sys *types.SystemContext, opts *tagsOptions, imgRef types.ImageReference) (string, []string, error) {
 	repositoryName := imgRef.DockerReference().Name()
 
 	tags, err := docker.GetRepositoryTags(ctx, sys, imgRef)
 	if err != nil {
 		return ``, nil, fmt.Errorf("Error listing repository tags: %w", err)
 	}
+
+	// If the user requests all tags before a certain threshold, then filter
+	if opts.filterOpts.FilterPresent() {
+		return filterDockerTags(ctx, sys, opts, repositoryName, tags)
+	}
+
 	return repositoryName, tags, nil
 }
 
@@ -114,7 +323,7 @@ func listDockerRepoTags(ctx context.Context, sys *types.SystemContext, opts *tag
 		return
 	}
 	if err = retry.IfNecessary(ctx, func() error {
-		repositoryName, tagListing, err = listDockerTags(ctx, sys, imgRef)
+		repositoryName, tagListing, err = listDockerTags(ctx, sys, opts, imgRef)
 		return err
 	}, opts.retryOpts); err != nil {
 		return

--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
-	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/mod v0.26.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.29.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -395,6 +395,8 @@ golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
 golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/mod v0.26.0 h1:EGMPT//Ezu+ylkCijjPc+f4Aih7sZvaAr+O3EHBxvZg=
+golang.org/x/mod v0.26.0/go.mod h1:/j6NAhSk8iQ723BGAUyoAcn7SlD7s15Dp9Nd/SfeaFQ=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -484,6 +486,7 @@ golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
 golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/vendor/golang.org/x/mod/semver/semver.go
+++ b/vendor/golang.org/x/mod/semver/semver.go
@@ -1,0 +1,407 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semver implements comparison of semantic version strings.
+// In this package, semantic version strings must begin with a leading "v",
+// as in "v1.0.0".
+//
+// The general form of a semantic version string accepted by this package is
+//
+//	vMAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]
+//
+// where square brackets indicate optional parts of the syntax;
+// MAJOR, MINOR, and PATCH are decimal integers without extra leading zeros;
+// PRERELEASE and BUILD are each a series of non-empty dot-separated identifiers
+// using only alphanumeric characters and hyphens; and
+// all-numeric PRERELEASE identifiers must not have leading zeros.
+//
+// This package follows Semantic Versioning 2.0.0 (see semver.org)
+// with two exceptions. First, it requires the "v" prefix. Second, it recognizes
+// vMAJOR and vMAJOR.MINOR (with no prerelease or build suffixes)
+// as shorthands for vMAJOR.0.0 and vMAJOR.MINOR.0.
+package semver
+
+import (
+	"slices"
+	"strings"
+)
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+}
+
+// IsValid reports whether v is a valid semantic version string.
+func IsValid(v string) bool {
+	_, ok := parse(v)
+	return ok
+}
+
+// Canonical returns the canonical formatting of the semantic version v.
+// It fills in any missing .MINOR or .PATCH and discards build metadata.
+// Two semantic versions compare equal only if their canonical formattings
+// are identical strings.
+// The canonical invalid semantic version is the empty string.
+func Canonical(v string) string {
+	p, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	if p.build != "" {
+		return v[:len(v)-len(p.build)]
+	}
+	if p.short != "" {
+		return v + p.short
+	}
+	return v
+}
+
+// Major returns the major version prefix of the semantic version v.
+// For example, Major("v2.1.0") == "v2".
+// If v is an invalid semantic version string, Major returns the empty string.
+func Major(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return v[:1+len(pv.major)]
+}
+
+// MajorMinor returns the major.minor version prefix of the semantic version v.
+// For example, MajorMinor("v2.1.0") == "v2.1".
+// If v is an invalid semantic version string, MajorMinor returns the empty string.
+func MajorMinor(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	i := 1 + len(pv.major)
+	if j := i + 1 + len(pv.minor); j <= len(v) && v[i] == '.' && v[i+1:j] == pv.minor {
+		return v[:j]
+	}
+	return v[:i] + "." + pv.minor
+}
+
+// Prerelease returns the prerelease suffix of the semantic version v.
+// For example, Prerelease("v2.1.0-pre+meta") == "-pre".
+// If v is an invalid semantic version string, Prerelease returns the empty string.
+func Prerelease(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.prerelease
+}
+
+// Build returns the build suffix of the semantic version v.
+// For example, Build("v2.1.0+meta") == "+meta".
+// If v is an invalid semantic version string, Build returns the empty string.
+func Build(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.build
+}
+
+// Compare returns an integer comparing two versions according to
+// semantic version precedence.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+//
+// An invalid semantic version string is considered less than a valid one.
+// All invalid semantic version strings compare equal to each other.
+func Compare(v, w string) int {
+	pv, ok1 := parse(v)
+	pw, ok2 := parse(w)
+	if !ok1 && !ok2 {
+		return 0
+	}
+	if !ok1 {
+		return -1
+	}
+	if !ok2 {
+		return +1
+	}
+	if c := compareInt(pv.major, pw.major); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.minor, pw.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.patch, pw.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(pv.prerelease, pw.prerelease)
+}
+
+// Max canonicalizes its arguments and then returns the version string
+// that compares greater.
+//
+// Deprecated: use [Compare] instead. In most cases, returning a canonicalized
+// version is not expected or desired.
+func Max(v, w string) string {
+	v = Canonical(v)
+	w = Canonical(w)
+	if Compare(v, w) > 0 {
+		return v
+	}
+	return w
+}
+
+// ByVersion implements [sort.Interface] for sorting semantic version strings.
+type ByVersion []string
+
+func (vs ByVersion) Len() int           { return len(vs) }
+func (vs ByVersion) Swap(i, j int)      { vs[i], vs[j] = vs[j], vs[i] }
+func (vs ByVersion) Less(i, j int) bool { return compareVersion(vs[i], vs[j]) < 0 }
+
+// Sort sorts a list of semantic version strings using [Compare] and falls back
+// to use [strings.Compare] if both versions are considered equal.
+func Sort(list []string) {
+	slices.SortFunc(list, compareVersion)
+}
+
+func compareVersion(a, b string) int {
+	cmp := Compare(a, b)
+	if cmp != 0 {
+		return cmp
+	}
+	return strings.Compare(a, b)
+}
+
+func parse(v string) (p parsed, ok bool) {
+	if v == "" || v[0] != 'v' {
+		return
+	}
+	p.major, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			return
+		}
+	}
+	if v != "" {
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+
+func isNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v)
+}
+
+func compareInt(x, y string) int {
+	if x == y {
+		return 0
+	}
+	if len(x) < len(y) {
+		return -1
+	}
+	if len(x) > len(y) {
+		return +1
+	}
+	if x < y {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func comparePrerelease(x, y string) int {
+	// "When major, minor, and patch are equal, a pre-release version has
+	// lower precedence than a normal version.
+	// Example: 1.0.0-alpha < 1.0.0.
+	// Precedence for two pre-release versions with the same major, minor,
+	// and patch version MUST be determined by comparing each dot separated
+	// identifier from left to right until a difference is found as follows:
+	// identifiers consisting of only digits are compared numerically and
+	// identifiers with letters or hyphens are compared lexically in ASCII
+	// sort order. Numeric identifiers always have lower precedence than
+	// non-numeric identifiers. A larger set of pre-release fields has a
+	// higher precedence than a smaller set, if all of the preceding
+	// identifiers are equal.
+	// Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta <
+	// 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0."
+	if x == y {
+		return 0
+	}
+	if x == "" {
+		return +1
+	}
+	if y == "" {
+		return -1
+	}
+	for x != "" && y != "" {
+		x = x[1:] // skip - or .
+		y = y[1:] // skip - or .
+		var dx, dy string
+		dx, x = nextIdent(x)
+		dy, y = nextIdent(y)
+		if dx != dy {
+			ix := isNum(dx)
+			iy := isNum(dy)
+			if ix != iy {
+				if ix {
+					return -1
+				} else {
+					return +1
+				}
+			}
+			if ix {
+				if len(dx) < len(dy) {
+					return -1
+				}
+				if len(dx) > len(dy) {
+					return +1
+				}
+			}
+			if dx < dy {
+				return -1
+			} else {
+				return +1
+			}
+		}
+	}
+	if x == "" {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func nextIdent(x string) (dx, rest string) {
+	i := 0
+	for i < len(x) && x[i] != '.' {
+		i++
+	}
+	return x[:i], x[i:]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -645,8 +645,9 @@ golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/salsa20/salsa
 golang.org/x/crypto/scrypt
 golang.org/x/crypto/sha3
-# golang.org/x/mod v0.23.0
-## explicit; go 1.22.0
+# golang.org/x/mod v0.26.0
+## explicit; go 1.23.0
+golang.org/x/mod/semver
 golang.org/x/mod/sumdb/note
 # golang.org/x/net v0.38.0
 ## explicit; go 1.23.0


### PR DESCRIPTION
Adds my prototyping changes from today in which I begin to translate our image prune tooling into something that could be contributed into `skopeo`.

I figured at first I could push to a `skopeo` branch but ended up not having access.  Just merging this into main in my fork so that I can continue to work off of main as I continue to prototype.  Eventually I will raise another PR against the main Skopeo repository.